### PR TITLE
feat: add IR control as alternative to cloud API

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,58 @@
 ## Compatibility and Requirements
 
 - Please note that this integration is designed for the latest series of Atomberg fans and may not work with older models.
-- The integration relies on cloud APIs for initialization.
+- The integration relies on cloud APIs for initialization (cloud control mode).
 - This integration uses UDP port `5625` for updating the fan state locally, make sure that port is not in use by any other application and that it is not blocked by any firewall.
+
+## Control Methods
+
+This integration supports two control methods. You choose which one to use during setup.
+
+### Cloud API Control
+
+Uses the Atomberg cloud APIs for fan control. Requires an `api_key` and `refresh_token` from the [Atomberg Developer Portal](https://developer.atomberg-iot.com/#overview). Provides full two-way state feedback (speed, power, light, etc.).
+
+### Infrared (IR) Control
+
+Uses an infrared transmitter to send NEC protocol commands directly to your Atomberg fan. No cloud credentials needed. Requires Home Assistant 2026.4.0 or later.
+
+#### Prerequisites
+
+1. **Home Assistant 2026.4.0+** — The integration depends on HA's built-in `infrared` entity platform.
+2. **An IR emitter device** — Any device that exposes an infrared transmitter entity to Home Assistant. Common options:
+   - **ESPHome IR proxy** — ESP32/ESP8266 with an IR LED, using the [`ir_rf_proxy`](https://esphome.io/components/ir_rf_proxy/) component.
+   - **Seeed XIAO IR Mate** — Dedicated IR blaster device.
+   - **Broadlink RM devices** — Via the Broadlink integration's infrared transmitter entities.
+
+#### Setup
+
+1. Ensure your IR emitter device is already set up in Home Assistant and appears as an infrared transmitter entity.
+2. Add the Atomberg integration and select **"Infrared (IR)"** as the control method.
+3. Select your fan model from the dropdown.
+4. Select the infrared transmitter entity to use.
+5. Position the IR emitter so it has line-of-sight to your Atomberg fan's IR receiver.
+
+#### Entities
+
+The IR setup creates the following entities:
+
+| Entity | Type | Description |
+|--------|------|-------------|
+| Fan | `fan` | On/off and speed control (6 speeds including boost) |
+| Boost | `button` | Activate boost mode (speed 6) |
+| LED | `button` | Toggle the fan's LED indicator |
+| Sleep Mode | `button` | Toggle sleep mode |
+| Timer | `button` | Toggle timer |
+| Timer 1 Hour | `button` | Set timer to 1 hour |
+| Timer 2 Hours | `button` | Set timer to 2 hours |
+| Timer 3 Hours | `button` | Set timer to 3 hours |
+| Timer 6 Hours | `button` | Set timer to 6 hours |
+
+#### Important Limitations
+
+- **One-way communication** — IR is transmit-only. The integration tracks assumed state internally but cannot detect if the fan is controlled by the physical remote. If you use the physical remote, resync the entity in Home Assistant by toggling it.
+- **Line of sight required** — The IR emitter must be able to "see" the fan's IR receiver. Obstructions will prevent commands from being received.
+- **NEC protocol** — Atomberg fans use NEC protocol with address `0xF300`. The IR codes are based on community-decoded values and are compatible with Gorilla Efficio, Renesa, Aris, Erica, and other Atomberg models.
 
 ## Contributions are welcome!
 

--- a/custom_components/atomberg/__init__.py
+++ b/custom_components/atomberg/__init__.py
@@ -8,11 +8,18 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
 from .api import AtombergCloudAPI
-from .const import CONF_REFRESH_TOKEN, DOMAIN, ENTRIES, UDP_LISTENER
+from .const import (
+    CONF_CONTROL_METHOD,
+    CONF_REFRESH_TOKEN,
+    DOMAIN,
+    ENTRIES,
+    UDP_LISTENER,
+    ControlMethod,
+)
 from .coordinator import AtombergDataUpdateCoordinator
 from .udp_listener import UDPListener
 
-PLATFORMS: list[Platform] = [
+CLOUD_PLATFORMS: list[Platform] = [
     Platform.FAN,
     Platform.SWITCH,
     Platform.LIGHT,
@@ -20,17 +27,30 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
 ]
 
+IR_PLATFORMS: list[Platform] = [
+    Platform.FAN,
+    Platform.BUTTON,
+]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Atomberg from a config entry."""
+    control_method = entry.data.get(CONF_CONTROL_METHOD, ControlMethod.CLOUD)
 
+    if control_method == ControlMethod.IR:
+        return await _async_setup_ir_entry(hass, entry)
+
+    return await _async_setup_cloud_entry(hass, entry)
+
+
+async def _async_setup_cloud_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Atomberg using cloud API."""
     domain_data = hass.data.setdefault(DOMAIN, {UDP_LISTENER: None, ENTRIES: {}})
 
     api = AtombergCloudAPI(
         hass, entry.data[CONF_API_KEY], entry.data[CONF_REFRESH_TOKEN]
     )
 
-    # Test API connection
     try:
         await api.test_connection()
     except Exception as e:
@@ -40,7 +60,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         udp_listener = UDPListener(hass)
         domain_data[UDP_LISTENER] = udp_listener
 
-        # Start the listener
         try:
             await udp_listener.start()
         except Exception:
@@ -53,30 +72,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     domain_data[ENTRIES][entry.entry_id] = coordinator
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, CLOUD_PLATFORMS)
 
+    return True
+
+
+async def _async_setup_ir_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Atomberg using IR control."""
+    await hass.config_entries.async_forward_entry_setups(entry, IR_PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    control_method = entry.data.get(CONF_CONTROL_METHOD, ControlMethod.CLOUD)
+
+    if control_method == ControlMethod.IR:
+        return await hass.config_entries.async_unload_platforms(entry, IR_PLATFORMS)
+
     domain_data = hass.data[DOMAIN]
     udp_listener: UDPListener = domain_data[UDP_LISTENER]
 
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, CLOUD_PLATFORMS)
     if not unload_ok:
         return False
 
-    # Discard the entry
     domain_data[ENTRIES].pop(entry.entry_id, None)
 
-    # Remove the callback from the udp listener
     udp_listener.remove_callback(entry)
 
-    # Close and remove the UDP listener if last entry
     if not domain_data[ENTRIES]:
         udp_listener.close()
-
         domain_data[UDP_LISTENER] = None
 
     return unload_ok

--- a/custom_components/atomberg/atomberg_ir_codes.py
+++ b/custom_components/atomberg/atomberg_ir_codes.py
@@ -1,7 +1,7 @@
 """Atomberg IR NEC command definitions."""
 
 from infrared_protocols import Command as InfraredCommand
-from infrared_protocols.protocols.nec import NECCommand
+from infrared_protocols import NECCommand
 
 ATOMBERG_IR_ADDRESS = 0xF300
 ATOMBERG_IR_MODULATION = 38000

--- a/custom_components/atomberg/atomberg_ir_codes.py
+++ b/custom_components/atomberg/atomberg_ir_codes.py
@@ -1,0 +1,45 @@
+"""Atomberg IR NEC command definitions."""
+
+from infrared_protocols import Command as InfraredCommand
+from infrared_protocols.protocols.nec import NECCommand
+
+ATOMBERG_IR_ADDRESS = 0xF300
+ATOMBERG_IR_MODULATION = 38000
+
+
+class AtombergIRCommand:
+    """NEC command codes for Atomberg fans."""
+
+    POWER = 0x6E91
+    SPEED_1 = 0x748B
+    SPEED_2 = 0x6F90
+    SPEED_3 = 0x758A
+    SPEED_4 = 0x6C93
+    SPEED_5 = 0x7788
+    BOOST = 0x708F
+    SLEEP = 0x718E
+    LED = 0xE916
+    TIMER = 0x6996
+    TIMER_1H = 0xA15E
+    TIMER_2H = 0x619E
+    TIMER_3H = 0x49B6
+    TIMER_6H = 0x31CE
+
+
+SPEED_MAP = {
+    1: AtombergIRCommand.SPEED_1,
+    2: AtombergIRCommand.SPEED_2,
+    3: AtombergIRCommand.SPEED_3,
+    4: AtombergIRCommand.SPEED_4,
+    5: AtombergIRCommand.SPEED_5,
+    6: AtombergIRCommand.BOOST,
+}
+
+
+def make_atomberg_command(command: int) -> InfraredCommand:
+    """Create an InfraredCommand from an Atomberg NEC command code."""
+    return NECCommand(
+        address=ATOMBERG_IR_ADDRESS,
+        command=command,
+        modulation=ATOMBERG_IR_MODULATION,
+    )

--- a/custom_components/atomberg/button.py
+++ b/custom_components/atomberg/button.py
@@ -5,6 +5,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_CONTROL_METHOD, ControlMethod
+from .ir_button import async_setup_entry as ir_async_setup_entry
 
 
 async def async_setup_entry(
@@ -14,7 +15,5 @@ async def async_setup_entry(
 ) -> None:
     """Set up Atomberg button entities from a config entry."""
     if entry.data.get(CONF_CONTROL_METHOD) == ControlMethod.IR:
-        from .ir_button import async_setup_entry as ir_async_setup_entry
-
         await ir_async_setup_entry(hass, entry, async_add_entities)
     # Cloud control has no button entities — nothing to set up.

--- a/custom_components/atomberg/button.py
+++ b/custom_components/atomberg/button.py
@@ -1,0 +1,20 @@
+"""Button platform for Atomberg integration."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_CONTROL_METHOD, ControlMethod
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Atomberg button entities from a config entry."""
+    if entry.data.get(CONF_CONTROL_METHOD) == ControlMethod.IR:
+        from .ir_button import async_setup_entry as ir_async_setup_entry
+
+        await ir_async_setup_entry(hass, entry, async_add_entities)
+    # Cloud control has no button entities — nothing to set up.

--- a/custom_components/atomberg/config_flow.py
+++ b/custom_components/atomberg/config_flow.py
@@ -6,21 +6,48 @@ import logging
 from typing import Any
 
 import voluptuous as vol
+from homeassistant.components.infrared import (
+    DOMAIN as INFRARED_DOMAIN,
+)
+from homeassistant.components.infrared import (
+    async_get_emitters,
+)
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from .api import AtombergCloudAPI, CannotConnect, InvalidAuth
-from .const import CONF_REFRESH_TOKEN, CONF_USE_CLOUD_CONTROL, DOMAIN, ENTRIES
+from .const import (
+    CONF_CONTROL_METHOD,
+    CONF_FAN_MODEL,
+    CONF_IR_EMITTER_ENTITY,
+    CONF_REFRESH_TOKEN,
+    CONF_USE_CLOUD_CONTROL,
+    DOMAIN,
+    ENTRIES,
+    FAN_MODEL_NAMES,
+    ControlMethod,
+    FanModel,
+)
 
 _LOGGER = logging.getLogger(__name__)
-STEP_USER_DATA_SCHEMA = vol.Schema(
+
+CLOUD_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_REFRESH_TOKEN): cv.string,
     }
 )
+
 OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USE_CLOUD_CONTROL, default=False): cv.boolean,
@@ -28,10 +55,12 @@ OPTIONS_SCHEMA = vol.Schema(
 )
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect."""
-    api_key = data["api_key"]
-    refresh_token = data["refresh_token"]
+async def validate_cloud_input(
+    hass: HomeAssistant, data: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate cloud API input."""
+    api_key = data[CONF_API_KEY]
+    refresh_token = data[CONF_REFRESH_TOKEN]
 
     api = AtombergCloudAPI(hass, api_key, refresh_token)
     await api.test_connection()
@@ -56,12 +85,38 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
         """Create the options flow."""
         return OptionsFlowHandler()
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None):
-        """Handle the initial step."""
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> Any:
+        """Handle the initial step - select control method."""
+        if user_input is not None:
+            control_method = user_input[CONF_CONTROL_METHOD]
+            if control_method == ControlMethod.CLOUD:
+                return await self.async_step_cloud()
+            return await self.async_step_ir()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_CONTROL_METHOD): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                ControlMethod.CLOUD.value,
+                                ControlMethod.IR.value,
+                            ],
+                            translation_key=CONF_CONTROL_METHOD,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_cloud(self, user_input: dict[str, Any] | None = None) -> Any:
+        """Handle cloud API setup."""
         errors: dict[str, str] = {}
         if user_input is not None:
             try:
-                info = await validate_input(self.hass, user_input)
+                info = await validate_cloud_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
@@ -70,10 +125,68 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                return self.async_create_entry(title=info["title"], data=user_input)
+                return self.async_create_entry(
+                    title=info["title"],
+                    data={
+                        **user_input,
+                        CONF_CONTROL_METHOD: ControlMethod.CLOUD,
+                    },
+                )
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="cloud",
+            data_schema=CLOUD_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_ir(self, user_input: dict[str, Any] | None = None) -> Any:
+        """Handle IR setup."""
+        emitter_entity_ids = async_get_emitters(self.hass)
+        if not emitter_entity_ids:
+            return self.async_abort(reason="no_ir_emitters")
+
+        if user_input is not None:
+            entity_id = user_input[CONF_IR_EMITTER_ENTITY]
+            fan_model = user_input[CONF_FAN_MODEL]
+
+            ent_reg = er.async_get(self.hass)
+            entry = ent_reg.async_get(entity_id)
+            entity_name = (
+                entry.name or entry.original_name or entity_id if entry else entity_id
+            )
+            model_name = FAN_MODEL_NAMES.get(fan_model, "Fan")
+            title = f"Atomberg {model_name} via {entity_name}"
+
+            await self.async_set_unique_id(f"atomberg_ir_{entity_id}_{fan_model}")
+            self._abort_if_unique_id_configured()
+
+            return self.async_create_entry(
+                title=title,
+                data={
+                    **user_input,
+                    CONF_CONTROL_METHOD: ControlMethod.IR,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="ir",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_FAN_MODEL): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[model.value for model in FanModel],
+                            translation_key=CONF_FAN_MODEL,
+                            mode=SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                    vol.Required(CONF_IR_EMITTER_ENTITY): EntitySelector(
+                        EntitySelectorConfig(
+                            domain=INFRARED_DOMAIN,
+                            include_entities=async_get_emitters(self.hass),
+                        )
+                    ),
+                }
+            ),
         )
 
 

--- a/custom_components/atomberg/const.py
+++ b/custom_components/atomberg/const.py
@@ -1,5 +1,7 @@
 """Constants for the Atomberg integration."""
 
+from enum import StrEnum
+
 DOMAIN = "atomberg"
 
 UDP_LISTENER = "udp_listener"
@@ -7,4 +9,33 @@ ENTRIES = "entries"
 
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_USE_CLOUD_CONTROL = "use_cloud_control"
+CONF_CONTROL_METHOD = "control_method"
+CONF_IR_EMITTER_ENTITY = "ir_emitter_entity"
+CONF_FAN_MODEL = "fan_model"
 MANUFACTURER = "Atomberg"
+
+
+class ControlMethod(StrEnum):
+    """Control method for Atomberg devices."""
+
+    CLOUD = "cloud"
+    IR = "ir"
+
+
+class FanModel(StrEnum):
+    """Supported Atomberg fan models for IR control."""
+
+    RENESA_PLUS = "renesa_plus"
+    ARIS = "aris"
+    ERICA = "erica"
+    GORILLA_EFFICIO = "gorilla_efficio"
+    GENERIC = "generic"
+
+
+FAN_MODEL_NAMES = {
+    FanModel.RENESA_PLUS: "Renesa+",
+    FanModel.ARIS: "Aris",
+    FanModel.ERICA: "Erica",
+    FanModel.GORILLA_EFFICIO: "Gorilla Efficio",
+    FanModel.GENERIC: "Generic",
+}

--- a/custom_components/atomberg/fan.py
+++ b/custom_components/atomberg/fan.py
@@ -17,6 +17,7 @@ from .const import CONF_CONTROL_METHOD, ControlMethod
 from .coordinator import AtombergDataUpdateCoordinator
 from .device import ATTR_POWER, ATTR_SPEED, AtombergDevice
 from .entity import AtombergEntity, platform_async_setup_entry
+from .ir_fan import async_setup_entry as ir_fan_async_setup_entry
 
 _LOGGER = getLogger(__name__)
 
@@ -30,9 +31,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up fan entities — routes to IR or cloud implementation."""
     if entry.data.get(CONF_CONTROL_METHOD) == ControlMethod.IR:
-        from .ir_fan import async_setup_entry as ir_async_setup_entry
-
-        await ir_async_setup_entry(hass, entry, async_add_entities)
+        await ir_fan_async_setup_entry(hass, entry, async_add_entities)
         return
 
     await platform_async_setup_entry(hass, entry, async_add_entities, AtombergFanEntity)

--- a/custom_components/atomberg/fan.py
+++ b/custom_components/atomberg/fan.py
@@ -13,6 +13,7 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
+from .const import CONF_CONTROL_METHOD, ControlMethod
 from .coordinator import AtombergDataUpdateCoordinator
 from .device import ATTR_POWER, ATTR_SPEED, AtombergDevice
 from .entity import AtombergEntity, platform_async_setup_entry
@@ -27,7 +28,13 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Automatically setup the fan entities from the devices list."""
+    """Set up fan entities — routes to IR or cloud implementation."""
+    if entry.data.get(CONF_CONTROL_METHOD) == ControlMethod.IR:
+        from .ir_fan import async_setup_entry as ir_async_setup_entry
+
+        await ir_async_setup_entry(hass, entry, async_add_entities)
+        return
+
     await platform_async_setup_entry(hass, entry, async_add_entities, AtombergFanEntity)
 
 

--- a/custom_components/atomberg/ir_button.py
+++ b/custom_components/atomberg/ir_button.py
@@ -1,0 +1,96 @@
+"""Button platform for Atomberg IR-controlled fans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .atomberg_ir_codes import AtombergIRCommand
+from .ir_entity import AtombergIrEntity
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class AtombergIrButtonDescription(ButtonEntityDescription):
+    """Describes an Atomberg IR button entity."""
+
+    command_code: int
+
+
+BUTTON_DESCRIPTIONS: tuple[AtombergIrButtonDescription, ...] = (
+    AtombergIrButtonDescription(
+        key="boost",
+        translation_key="boost",
+        command_code=AtombergIRCommand.BOOST,
+    ),
+    AtombergIrButtonDescription(
+        key="led",
+        translation_key="led",
+        command_code=AtombergIRCommand.LED,
+    ),
+    AtombergIrButtonDescription(
+        key="sleep",
+        translation_key="sleep",
+        command_code=AtombergIRCommand.SLEEP,
+    ),
+    AtombergIrButtonDescription(
+        key="timer",
+        translation_key="timer",
+        command_code=AtombergIRCommand.TIMER,
+    ),
+    AtombergIrButtonDescription(
+        key="timer_1h",
+        translation_key="timer_1h",
+        command_code=AtombergIRCommand.TIMER_1H,
+    ),
+    AtombergIrButtonDescription(
+        key="timer_2h",
+        translation_key="timer_2h",
+        command_code=AtombergIRCommand.TIMER_2H,
+    ),
+    AtombergIrButtonDescription(
+        key="timer_3h",
+        translation_key="timer_3h",
+        command_code=AtombergIRCommand.TIMER_3H,
+    ),
+    AtombergIrButtonDescription(
+        key="timer_6h",
+        translation_key="timer_6h",
+        command_code=AtombergIRCommand.TIMER_6H,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Atomberg IR buttons from config entry."""
+    async_add_entities(
+        AtombergIrButton(entry, description) for description in BUTTON_DESCRIPTIONS
+    )
+
+
+class AtombergIrButton(AtombergIrEntity, ButtonEntity):
+    """Atomberg IR button entity."""
+
+    entity_description: AtombergIrButtonDescription
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        description: AtombergIrButtonDescription,
+    ) -> None:
+        """Initialize Atomberg IR button."""
+        super().__init__(entry, unique_id_suffix=f"ir_button_{description.key}")
+        self.entity_description = description
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self._send_command(self.entity_description.command_code)

--- a/custom_components/atomberg/ir_entity.py
+++ b/custom_components/atomberg/ir_entity.py
@@ -1,0 +1,88 @@
+"""Base entity for Atomberg IR-controlled devices."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.infrared import async_send_command
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import Event, EventStateChangedData, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .atomberg_ir_codes import make_atomberg_command
+from .const import (
+    CONF_FAN_MODEL,
+    CONF_IR_EMITTER_ENTITY,
+    DOMAIN,
+    FAN_MODEL_NAMES,
+    MANUFACTURER,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AtombergIrEntity(Entity):
+    """Base entity for Atomberg IR-controlled devices."""
+
+    _attr_has_entity_name = True
+    _attr_assumed_state = True
+
+    def __init__(self, entry: ConfigEntry, unique_id_suffix: str) -> None:
+        """Initialize Atomberg IR entity."""
+        self._infrared_entity_id = entry.data[CONF_IR_EMITTER_ENTITY]
+        self._attr_unique_id = f"{entry.entry_id}_{unique_id_suffix}"
+
+        fan_model = entry.data.get(CONF_FAN_MODEL, "generic")
+        model_name = FAN_MODEL_NAMES.get(fan_model, "Atomberg Fan")
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=f"Atomberg {model_name}",
+            manufacturer=MANUFACTURER,
+            model=model_name,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to infrared entity state changes."""
+        await super().async_added_to_hass()
+
+        @callback
+        def _async_ir_state_changed(event: Event[EventStateChangedData]) -> None:
+            """Handle infrared entity state changes."""
+            new_state = event.data["new_state"]
+            ir_available = (
+                new_state is not None and new_state.state != STATE_UNAVAILABLE
+            )
+            if ir_available != self.available:
+                _LOGGER.debug(
+                    "IR emitter %s used by %s is %s",
+                    self._infrared_entity_id,
+                    self.entity_id,
+                    "available" if ir_available else "unavailable",
+                )
+                self._attr_available = ir_available
+                self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [self._infrared_entity_id], _async_ir_state_changed
+            )
+        )
+
+        ir_state = self.hass.states.get(self._infrared_entity_id)
+        self._attr_available = (
+            ir_state is not None and ir_state.state != STATE_UNAVAILABLE
+        )
+
+    async def _send_command(self, command_code: int) -> None:
+        """Send an IR command to the Atomberg fan."""
+        ir_command = make_atomberg_command(command_code)
+        await async_send_command(
+            self.hass,
+            self._infrared_entity_id,
+            ir_command,
+            context=self._context,
+        )

--- a/custom_components/atomberg/ir_fan.py
+++ b/custom_components/atomberg/ir_fan.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
 
 
 class AtombergIrFanEntity(AtombergIrEntity, FanEntity):
-    """Atomberg IR fan entity."""
+    """Atomberg IR fan entity with optimistic/assumed state management."""
 
     _attr_name = None
     _attr_supported_features = (
@@ -41,7 +41,10 @@ class AtombergIrFanEntity(AtombergIrEntity, FanEntity):
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize Atomberg IR fan entity."""
         super().__init__(entry, unique_id_suffix="ir_fan")
-        self._attr_is_on = False
+        # percentage=0 means off; FanEntity.is_on is derived from percentage > 0
+        self._attr_percentage = 0
+        # Tracks the last non-zero speed so Turn On can resume at it
+        self._last_on_percentage: int = round(100 / self._attr_speed_count)  # speed 1
 
     async def async_turn_on(
         self,
@@ -50,22 +53,19 @@ class AtombergIrFanEntity(AtombergIrEntity, FanEntity):
         **kwargs,
     ) -> None:
         """Turn on the fan."""
-        if not self._attr_is_on:
-            await self._send_command(AtombergIRCommand.POWER)
-            self._attr_is_on = True
-
+        await self._send_command(AtombergIRCommand.POWER)
         if percentage is not None:
             await self.async_set_percentage(percentage)
             return
-
+        # Resume at last known speed (defaults to speed 1 on first use)
+        self._attr_percentage = self._last_on_percentage
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the fan."""
-        if self._attr_is_on:
-            await self._send_command(AtombergIRCommand.POWER)
-            self._attr_is_on = False
-            self.async_write_ha_state()
+        await self._send_command(AtombergIRCommand.POWER)
+        self._attr_percentage = 0
+        self.async_write_ha_state()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
@@ -73,12 +73,13 @@ class AtombergIrFanEntity(AtombergIrEntity, FanEntity):
             await self.async_turn_off()
             return
 
-        if not self._attr_is_on:
+        # If currently off, send power-on first
+        if self._attr_percentage == 0:
             await self._send_command(AtombergIRCommand.POWER)
-            self._attr_is_on = True
 
-        speed = math.ceil(percentage / 100 * self._attr_speed_count)
-        speed = max(1, min(speed, 6))
-
+        speed = max(1, min(6, math.ceil(percentage / 100 * self._attr_speed_count)))
         await self._send_command(SPEED_MAP[speed])
+
+        self._attr_percentage = percentage
+        self._last_on_percentage = percentage
         self.async_write_ha_state()

--- a/custom_components/atomberg/ir_fan.py
+++ b/custom_components/atomberg/ir_fan.py
@@ -1,0 +1,84 @@
+"""Fan platform for Atomberg IR-controlled fans."""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .atomberg_ir_codes import SPEED_MAP, AtombergIRCommand
+from .ir_entity import AtombergIrEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Atomberg IR fan from config entry."""
+    async_add_entities([AtombergIrFanEntity(entry)])
+
+
+class AtombergIrFanEntity(AtombergIrEntity, FanEntity):
+    """Atomberg IR fan entity."""
+
+    _attr_name = None
+    _attr_supported_features = (
+        FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+        | FanEntityFeature.SET_SPEED
+    )
+    _attr_speed_count = 6
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize Atomberg IR fan entity."""
+        super().__init__(entry, unique_id_suffix="ir_fan")
+        self._attr_is_on = False
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs,
+    ) -> None:
+        """Turn on the fan."""
+        if not self._attr_is_on:
+            await self._send_command(AtombergIRCommand.POWER)
+            self._attr_is_on = True
+
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+            return
+
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn off the fan."""
+        if self._attr_is_on:
+            await self._send_command(AtombergIRCommand.POWER)
+            self._attr_is_on = False
+            self.async_write_ha_state()
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
+        if not self._attr_is_on:
+            await self._send_command(AtombergIRCommand.POWER)
+            self._attr_is_on = True
+
+        speed = math.ceil(percentage / 100 * self._attr_speed_count)
+        speed = max(1, min(speed, 6))
+
+        await self._send_command(SPEED_MAP[speed])
+        self.async_write_ha_state()

--- a/custom_components/atomberg/manifest.json
+++ b/custom_components/atomberg/manifest.json
@@ -5,9 +5,9 @@
     "@dasshubham762"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["infrared"],
   "documentation": "https://github.com/dasshubham762/atomberg-integration",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/dasshubham762/atomberg-integration/issues",
-  "version": "2.1.4"
+  "version": "2.2.0"
 }

--- a/custom_components/atomberg/strings.json
+++ b/custom_components/atomberg/strings.json
@@ -2,11 +2,30 @@
   "config": {
     "step": {
       "user": {
-        "title": "[%key:common::config_flow::title%]",
-        "description": "[%key:common::config_flow::description%]",
+        "title": "Choose Control Method",
+        "description": "Select how you want to control your Atomberg fan. Cloud control requires API credentials. IR control requires an infrared emitter device (e.g., ESPHome IR proxy).",
+        "data": {
+          "control_method": "Control method"
+        }
+      },
+      "cloud": {
+        "title": "Atomberg Cloud Configuration",
+        "description": "Input the credentials for Atomberg Cloud API.",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "refresh_token": "[%key:common::config_flow::data::refresh_token%]"
+        }
+      },
+      "ir": {
+        "title": "Atomberg IR Configuration",
+        "description": "Select your fan model and the infrared transmitter entity to use for controlling your Atomberg fan.",
+        "data": {
+          "fan_model": "Fan model",
+          "ir_emitter_entity": "Infrared transmitter"
+        },
+        "data_description": {
+          "fan_model": "The model of your Atomberg fan.",
+          "ir_emitter_entity": "The infrared transmitter entity to use for sending commands."
         }
       }
     },
@@ -14,6 +33,9 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "no_ir_emitters": "No infrared transmitter entities found. Please set up an infrared device first (e.g., ESPHome IR proxy)."
     }
   },
   "options": {
@@ -26,6 +48,51 @@
         "data_description": {
           "use_cloud_control": "[%key:common::options_flow::data_description::use_cloud_control%]"
         }
+      }
+    }
+  },
+  "entity": {
+    "button": {
+      "boost": {
+        "name": "Boost"
+      },
+      "led": {
+        "name": "LED"
+      },
+      "sleep": {
+        "name": "Sleep Mode"
+      },
+      "timer": {
+        "name": "Timer"
+      },
+      "timer_1h": {
+        "name": "Timer 1 Hour"
+      },
+      "timer_2h": {
+        "name": "Timer 2 Hours"
+      },
+      "timer_3h": {
+        "name": "Timer 3 Hours"
+      },
+      "timer_6h": {
+        "name": "Timer 6 Hours"
+      }
+    }
+  },
+  "selector": {
+    "control_method": {
+      "options": {
+        "cloud": "Cloud API",
+        "ir": "Infrared (IR)"
+      }
+    },
+    "fan_model": {
+      "options": {
+        "renesa_plus": "Renesa+",
+        "aris": "Aris",
+        "erica": "Erica",
+        "gorilla_efficio": "Gorilla Efficio",
+        "generic": "Generic"
       }
     }
   }

--- a/custom_components/atomberg/translations/en.json
+++ b/custom_components/atomberg/translations/en.json
@@ -2,11 +2,30 @@
   "config": {
     "step": {
       "user": {
+        "title": "Choose Control Method",
+        "description": "Select how you want to control your Atomberg fan. Cloud control requires API credentials. IR control requires an infrared emitter device (e.g., ESPHome IR proxy).",
+        "data": {
+          "control_method": "Control method"
+        }
+      },
+      "cloud": {
         "title": "Atomberg Cloud Configuration",
         "description": "Input the credentials for Atomberg Cloud API.",
         "data": {
           "api_key": "API key",
           "refresh_token": "Refresh token"
+        }
+      },
+      "ir": {
+        "title": "Atomberg IR Configuration",
+        "description": "Select your fan model and the infrared transmitter entity to use for controlling your Atomberg fan.",
+        "data": {
+          "fan_model": "Fan model",
+          "ir_emitter_entity": "Infrared transmitter"
+        },
+        "data_description": {
+          "fan_model": "The model of your Atomberg fan.",
+          "ir_emitter_entity": "The infrared transmitter entity to use for sending commands."
         }
       }
     },
@@ -14,6 +33,9 @@
       "cannot_connect": "Cannot connect to Atomberg integration.",
       "invalid_auth": "Failed to authenticate with server.",
       "unknown": "An unknown error occurred. See log for details."
+    },
+    "abort": {
+      "no_ir_emitters": "No infrared transmitter entities found. Please set up an infrared device first (e.g., ESPHome IR proxy)."
     }
   },
   "options": {
@@ -26,6 +48,51 @@
         "data_description": {
           "use_cloud_control": "When enabled, the integration will send control commands to the Atomberg cloud APIs instead of directly to the device."
         }
+      }
+    }
+  },
+  "entity": {
+    "button": {
+      "boost": {
+        "name": "Boost"
+      },
+      "led": {
+        "name": "LED"
+      },
+      "sleep": {
+        "name": "Sleep Mode"
+      },
+      "timer": {
+        "name": "Timer"
+      },
+      "timer_1h": {
+        "name": "Timer 1 Hour"
+      },
+      "timer_2h": {
+        "name": "Timer 2 Hours"
+      },
+      "timer_3h": {
+        "name": "Timer 3 Hours"
+      },
+      "timer_6h": {
+        "name": "Timer 6 Hours"
+      }
+    }
+  },
+  "selector": {
+    "control_method": {
+      "options": {
+        "cloud": "Cloud API",
+        "ir": "Infrared (IR)"
+      }
+    },
+    "fan_model": {
+      "options": {
+        "renesa_plus": "Renesa+",
+        "aris": "Aris",
+        "erica": "Erica",
+        "gorilla_efficio": "Gorilla Efficio",
+        "generic": "Generic"
       }
     }
   }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Atomberg",
-  "homeassistant": "2025.1.0",
+  "homeassistant": "2026.4.0",
   "render_readme": true
 }


### PR DESCRIPTION
Add infrared control as a second control method alongside the existing cloud API. Users can now choose between cloud or IR during setup. 

Please refer issue #47 for feature request

- New IR platform files: ir_entity, ir_fan, ir_button, atomberg_ir_codes
- Branching config flow: user selects control method first
- Bundled NEC IR codes (address 0xF300) for all Atomberg functions
- FanEntity with 6 speeds + 8 button entities (boost, LED, sleep, timers)
- Requires HA 2026.4.0+ for the infrared entity platform
- README updated with IR setup guide and limitations