### PR TITLE
Add M2 series (Aris) to supported devices

### DIFF
--- a/custom_components/atomberg/api.py
+++ b/custom_components/atomberg/api.py
@@ -15,7 +15,7 @@ from requests import Response
 
 _LOGGER = getLogger(__name__)
 
-SUPPORTED_SERIES = ["R1", "R2", "K1", "I1", "I2", "I3", "M1", "S1"]
+SUPPORTED_SERIES = ["R1", "R2", "K1", "I1", "I2", "I3", "M1", "M2", "S1"]
 
 
 class AtombergCloudAPI:


### PR DESCRIPTION
## Summary
- Adds `M2` to `SUPPORTED_SERIES` in `api.py`
- Aris and Aris Contour fans use series code `M2`, which was missing — causing them to be silently filtered out during device sync (zero devices, zero logs)

Fixes #46

## Test plan
- [ ] Configure integration with an Atomberg account that has Aris/Aris Contour fans
- [ ] Verify devices appear after integration reload
- [ ] Verify fan control (on/off, speed) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for M2 device series. Device discovery and synchronization will now detect and include M2 devices alongside existing supported series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->