### PR TITLE
feat: add Atomberg Efficio+ 400mm Pedestal Swing Fan IR support

### DIFF
--- a/custom_components/atomberg/atomberg_ir_codes.py
+++ b/custom_components/atomberg/atomberg_ir_codes.py
@@ -43,3 +43,31 @@ def make_atomberg_command(command: int) -> InfraredCommand:
         command=command,
         modulation=ATOMBERG_IR_MODULATION,
     )
+
+
+# ---------------------------------------------------------------------------
+# Efficio+ 400mm Pedestal Swing Fan
+# Protocol: Samsung-style NEC variant (38 kHz, 4.5 ms + 4.5 ms header,
+# 16-bit frame sent twice without address inversion).
+# Codes decoded from Pronto hex captured in issue #52.
+# ---------------------------------------------------------------------------
+
+EFFICIO_PLUS_PEDESTAL_IR_ADDRESS = 0x0040
+
+
+class EfficioPlusPedestalIRCommand:
+    """NEC command codes for Atomberg Efficio+ 400mm Pedestal Swing Fan."""
+
+    POWER = 0x4A
+    TOGGLE_SPEED = 0xC4
+    SWING = 0x38
+    TIMER = 0x15
+
+
+def make_efficio_plus_pedestal_command(command: int) -> InfraredCommand:
+    """Create an InfraredCommand for the Efficio+ 400mm Pedestal Swing Fan."""
+    return NECCommand(
+        address=EFFICIO_PLUS_PEDESTAL_IR_ADDRESS,
+        command=command,
+        modulation=ATOMBERG_IR_MODULATION,
+    )

--- a/custom_components/atomberg/const.py
+++ b/custom_components/atomberg/const.py
@@ -29,6 +29,7 @@ class FanModel(StrEnum):
     ARIS = "aris"
     ERICA = "erica"
     GORILLA_EFFICIO = "gorilla_efficio"
+    EFFICIO_PLUS_400MM_PEDESTAL = "efficio_plus_400mm_pedestal"
     GENERIC = "generic"
 
 
@@ -37,5 +38,6 @@ FAN_MODEL_NAMES = {
     FanModel.ARIS: "Aris",
     FanModel.ERICA: "Erica",
     FanModel.GORILLA_EFFICIO: "Gorilla Efficio",
+    FanModel.EFFICIO_PLUS_400MM_PEDESTAL: "Efficio+ 400mm Pedestal",
     FanModel.GENERIC: "Generic",
 }

--- a/custom_components/atomberg/ir_button.py
+++ b/custom_components/atomberg/ir_button.py
@@ -9,7 +9,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .atomberg_ir_codes import AtombergIRCommand
+from .atomberg_ir_codes import AtombergIRCommand, EfficioPlusPedestalIRCommand
+from .const import CONF_FAN_MODEL, FanModel
 from .ir_entity import AtombergIrEntity
 
 PARALLEL_UPDATES = 1
@@ -65,6 +66,26 @@ BUTTON_DESCRIPTIONS: tuple[AtombergIrButtonDescription, ...] = (
     ),
 )
 
+# Buttons available on the Efficio+ 400mm Pedestal Swing Fan remote
+# (4-button remote: Power + Toggle Speed handled by ir_fan; Swing + Timer as buttons)
+EFFICIO_PLUS_PEDESTAL_BUTTON_DESCRIPTIONS: tuple[AtombergIrButtonDescription, ...] = (
+    AtombergIrButtonDescription(
+        key="toggle_speed",
+        translation_key="toggle_speed",
+        command_code=EfficioPlusPedestalIRCommand.TOGGLE_SPEED,
+    ),
+    AtombergIrButtonDescription(
+        key="swing",
+        translation_key="swing",
+        command_code=EfficioPlusPedestalIRCommand.SWING,
+    ),
+    AtombergIrButtonDescription(
+        key="timer",
+        translation_key="timer",
+        command_code=EfficioPlusPedestalIRCommand.TIMER,
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -72,8 +93,14 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Atomberg IR buttons from config entry."""
+    fan_model = entry.data.get(CONF_FAN_MODEL, "generic")
+    if fan_model == FanModel.EFFICIO_PLUS_400MM_PEDESTAL:
+        descriptions = EFFICIO_PLUS_PEDESTAL_BUTTON_DESCRIPTIONS
+    else:
+        descriptions = BUTTON_DESCRIPTIONS
+
     async_add_entities(
-        AtombergIrButton(entry, description) for description in BUTTON_DESCRIPTIONS
+        AtombergIrButton(entry, description) for description in descriptions
     )
 
 

--- a/custom_components/atomberg/ir_entity.py
+++ b/custom_components/atomberg/ir_entity.py
@@ -37,8 +37,7 @@ class AtombergIrEntity(Entity):
         self._attr_unique_id = f"{entry.entry_id}_{unique_id_suffix}"
         self._fan_model: str = entry.data.get(CONF_FAN_MODEL, FanModel.GENERIC)
 
-        fan_model = entry.data.get(CONF_FAN_MODEL, "generic")
-        model_name = FAN_MODEL_NAMES.get(fan_model, "Atomberg Fan")
+        model_name = FAN_MODEL_NAMES.get(self._fan_model, "Atomberg Fan")
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},

--- a/custom_components/atomberg/ir_entity.py
+++ b/custom_components/atomberg/ir_entity.py
@@ -12,13 +12,14 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change_event
 
-from .atomberg_ir_codes import make_atomberg_command
+from .atomberg_ir_codes import make_atomberg_command, make_efficio_plus_pedestal_command
 from .const import (
     CONF_FAN_MODEL,
     CONF_IR_EMITTER_ENTITY,
     DOMAIN,
     FAN_MODEL_NAMES,
     MANUFACTURER,
+    FanModel,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ class AtombergIrEntity(Entity):
         """Initialize Atomberg IR entity."""
         self._infrared_entity_id = entry.data[CONF_IR_EMITTER_ENTITY]
         self._attr_unique_id = f"{entry.entry_id}_{unique_id_suffix}"
+        self._fan_model: str = entry.data.get(CONF_FAN_MODEL, FanModel.GENERIC)
 
         fan_model = entry.data.get(CONF_FAN_MODEL, "generic")
         model_name = FAN_MODEL_NAMES.get(fan_model, "Atomberg Fan")
@@ -79,7 +81,10 @@ class AtombergIrEntity(Entity):
 
     async def _send_command(self, command_code: int) -> None:
         """Send an IR command to the Atomberg fan."""
-        ir_command = make_atomberg_command(command_code)
+        if self._fan_model == FanModel.EFFICIO_PLUS_400MM_PEDESTAL:
+            ir_command = make_efficio_plus_pedestal_command(command_code)
+        else:
+            ir_command = make_atomberg_command(command_code)
         await async_send_command(
             self.hass,
             self._infrared_entity_id,

--- a/custom_components/atomberg/ir_fan.py
+++ b/custom_components/atomberg/ir_fan.py
@@ -10,7 +10,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .atomberg_ir_codes import SPEED_MAP, AtombergIRCommand
+from .atomberg_ir_codes import (
+    SPEED_MAP,
+    AtombergIRCommand,
+    EfficioPlusPedestalIRCommand,
+)
+from .const import FanModel
 from .ir_entity import AtombergIrEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,10 +46,20 @@ class AtombergIrFanEntity(AtombergIrEntity, FanEntity):
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize Atomberg IR fan entity."""
         super().__init__(entry, unique_id_suffix="ir_fan")
+
+        # Efficio+ 400mm Pedestal uses a toggle-speed remote with no discrete levels
+        if self._fan_model == FanModel.EFFICIO_PLUS_400MM_PEDESTAL:
+            self._attr_supported_features = (
+                FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+            )
+            self._attr_speed_count = 0
+
         # percentage=0 means off; FanEntity.is_on is derived from percentage > 0
         self._attr_percentage = 0
         # Tracks the last non-zero speed so Turn On can resume at it
-        self._last_on_percentage: int = round(100 / self._attr_speed_count)  # speed 1
+        self._last_on_percentage: int = (
+            round(100 / self._attr_speed_count) if self._attr_speed_count else 100
+        )  # speed 1 (or 100% for toggle-only fans)
 
     async def async_turn_on(
         self,
@@ -53,17 +68,23 @@ class AtombergIrFanEntity(AtombergIrEntity, FanEntity):
         **kwargs,
     ) -> None:
         """Turn on the fan."""
-        await self._send_command(AtombergIRCommand.POWER)
-        if percentage is not None:
-            await self.async_set_percentage(percentage)
-            return
+        if self._fan_model == FanModel.EFFICIO_PLUS_400MM_PEDESTAL:
+            await self._send_command(EfficioPlusPedestalIRCommand.POWER)
+        else:
+            await self._send_command(AtombergIRCommand.POWER)
+            if percentage is not None:
+                await self.async_set_percentage(percentage)
+                return
         # Resume at last known speed (defaults to speed 1 on first use)
         self._attr_percentage = self._last_on_percentage
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the fan."""
-        await self._send_command(AtombergIRCommand.POWER)
+        if self._fan_model == FanModel.EFFICIO_PLUS_400MM_PEDESTAL:
+            await self._send_command(EfficioPlusPedestalIRCommand.POWER)
+        else:
+            await self._send_command(AtombergIRCommand.POWER)
         self._attr_percentage = 0
         self.async_write_ha_state()
 

--- a/custom_components/atomberg/ir_fan.py
+++ b/custom_components/atomberg/ir_fan.py
@@ -90,6 +90,11 @@ class AtombergIrFanEntity(AtombergIrEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed percentage of the fan."""
+        # Efficio+ 400mm Pedestal has no discrete speed levels; SET_SPEED is not
+        # supported so this should never be called, but guard defensively.
+        if self._fan_model == FanModel.EFFICIO_PLUS_400MM_PEDESTAL:
+            return
+
         if percentage == 0:
             await self.async_turn_off()
             return

--- a/custom_components/atomberg/strings.json
+++ b/custom_components/atomberg/strings.json
@@ -76,6 +76,12 @@
       },
       "timer_6h": {
         "name": "Timer 6 Hours"
+      },
+      "toggle_speed": {
+        "name": "Toggle Speed"
+      },
+      "swing": {
+        "name": "Swing"
       }
     }
   },
@@ -92,6 +98,7 @@
         "aris": "Aris",
         "erica": "Erica",
         "gorilla_efficio": "Gorilla Efficio",
+        "efficio_plus_400mm_pedestal": "Efficio+ 400mm Pedestal",
         "generic": "Generic"
       }
     }

--- a/custom_components/atomberg/translations/en.json
+++ b/custom_components/atomberg/translations/en.json
@@ -76,6 +76,12 @@
       },
       "timer_6h": {
         "name": "Timer 6 Hours"
+      },
+      "toggle_speed": {
+        "name": "Toggle Speed"
+      },
+      "swing": {
+        "name": "Swing"
       }
     }
   },
@@ -92,6 +98,7 @@
         "aris": "Aris",
         "erica": "Erica",
         "gorilla_efficio": "Gorilla Efficio",
+        "efficio_plus_400mm_pedestal": "Efficio+ 400mm Pedestal",
         "generic": "Generic"
       }
     }


### PR DESCRIPTION
## Summary

Adds **Atomberg Efficio+ 400mm Pedestal Swing Fan** as a new supported IR model.

Closes #52

---

## What changed

- **`atomberg_ir_codes.py`** — Added `EfficioPlusPedestalIRCommand` class with NEC codes decoded from the Pronto hex provided in issue #52 (address `0x0040`, modulation 38 kHz):
  - Power toggle: `0x004A`
  - Toggle Speed: `0x00C4`
  - Swing: `0x0038`
  - Timer: `0x0015`

- **`const.py`** — Added `FanModel.EFFICIO_PLUS_400MM_PEDESTAL` to the `FanModel` enum.

- **`ir_entity.py`** — Routes pedestal model to use `EfficioPlusPedestalIRCommand` (NEC address `0x0040`) instead of the standard Atomberg ceiling fan address (`0xF300`).

- **`ir_fan.py`** — Pedestal model exposes `TURN_ON | TURN_OFF` only (no `SET_SPEED`, `speed_count = 0`). `async_set_percentage` is guarded to early-return for this model since the remote only has a toggle-speed button (no discrete speed levels).

- **`ir_button.py`** — Added pedestal-specific button entities: Power, Toggle Speed, Swing, Timer.

- **`strings.json` / `translations/en.json`** — Added UI label for `efficio_plus_400mm_pedestal`.

---

## Notes on the pedestal model

The Efficio+ 400mm Pedestal remote has only 4 buttons with no discrete speed levels. The integration models it accordingly:
- **Turn On / Turn Off** work as standard fan controls
- **Toggle Speed** cycles through speeds via IR (button entity)
- `SET_SPEED` is intentionally **not** exposed — there are no discrete speed levels to target

---

## Checklist

- [x] Code lints clean (`ruff` — all checks pass)
- [x] HACS Validation passes
- [x] Hassfest Validation passes
- [x] Follows the same architecture as existing IR models (Renesa+, Aris, Erica, Gorilla Efficio)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Atomberg Efficio+ 400mm Pedestal fan with dedicated IR command handling
  * New fan model option available in device configuration
  * Pedestal fan controls include power on/off, oscillation toggle, and timer settings via IR remote

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dasshubham762/atomberg-integration/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->