### PR TITLE
feat: add local auto-discovery and onboarding for network connected fans

### DIFF
--- a/custom_components/atomberg/__init__.py
+++ b/custom_components/atomberg/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
+import logging
+
+from homeassistant.config_entries import SOURCE_INTEGRATION_DISCOVERY, ConfigEntry
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
@@ -10,14 +12,20 @@ from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from .api import AtombergCloudAPI
 from .const import (
     CONF_CONTROL_METHOD,
+    CONF_DEVICE_ID,
+    CONF_DEVICE_SERIES,
+    CONF_IP_ADDRESS,
     CONF_REFRESH_TOKEN,
     DOMAIN,
     ENTRIES,
+    SETUP_ACTIVE,
     UDP_LISTENER,
     ControlMethod,
 )
 from .coordinator import AtombergDataUpdateCoordinator
-from .udp_listener import UDPListener
+from .udp_listener import DISCOVERY_CALLBACK_KEY, UDPListener
+
+_LOGGER = logging.getLogger(__name__)
 
 CLOUD_PLATFORMS: list[Platform] = [
     Platform.FAN,
@@ -32,6 +40,63 @@ IR_PLATFORMS: list[Platform] = [
     Platform.BUTTON,
 ]
 
+LOCAL_UDP_PLATFORMS: list[Platform] = [
+    Platform.FAN,
+    Platform.SWITCH,
+    Platform.LIGHT,
+    Platform.SENSOR,
+    Platform.SELECT,
+]
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the Atomberg integration domain.
+
+    Runs before any config entries are loaded.  Starts the shared UDP listener
+    early so that device broadcasts can trigger automatic discovery flows even
+    when no entries exist yet.
+    """
+    domain_data = hass.data.setdefault(DOMAIN, {UDP_LISTENER: None, ENTRIES: {}})
+
+    udp_listener = UDPListener(hass)
+    try:
+        await udp_listener.start()
+    except Exception:
+        _LOGGER.warning(
+            "Atomberg: failed to start UDP listener during integration setup; "
+            "local discovery will not be available until an entry is configured."
+        )
+        return True
+
+    domain_data[UDP_LISTENER] = udp_listener
+    domain_data[SETUP_ACTIVE] = True
+
+    def _discovery_callback(msg_data: dict) -> None:
+        """Fire an integration-discovery flow for previously-unknown devices."""
+        device_id = msg_data.get("device_id")
+        if not device_id:
+            return
+
+        # Skip if this device is already managed by an existing local entry.
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.data.get(CONF_DEVICE_ID) == device_id:
+                return
+
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_INTEGRATION_DISCOVERY},
+                data={
+                    CONF_DEVICE_ID: device_id,
+                    CONF_DEVICE_SERIES: msg_data.get("device_series"),
+                    CONF_IP_ADDRESS: msg_data.get("ip_address"),
+                },
+            )
+        )
+
+    udp_listener.add_callback(DISCOVERY_CALLBACK_KEY, _discovery_callback)
+    return True
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Atomberg from a config entry."""
@@ -39,6 +104,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if control_method == ControlMethod.IR:
         return await _async_setup_ir_entry(hass, entry)
+
+    if control_method == ControlMethod.LOCAL_DISCOVERY:
+        return await _async_setup_local_discovery_entry(hass, entry)
+
+    if control_method == ControlMethod.LOCAL_UDP:
+        return await _async_setup_local_udp_entry(hass, entry)
 
     return await _async_setup_cloud_entry(hass, entry)
 
@@ -68,12 +139,57 @@ async def _async_setup_cloud_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         udp_listener = domain_data[UDP_LISTENER]
 
     coordinator = AtombergDataUpdateCoordinator(
-        hass=hass, api=api, udp_listener=udp_listener
+        hass=hass,
+        api=api,
+        udp_listener=udp_listener,
+        config_entry=entry,
     )
     domain_data[ENTRIES][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, CLOUD_PLATFORMS)
 
+    return True
+
+
+async def _async_setup_local_udp_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Atomberg using local UDP control (no cloud credentials required)."""
+    domain_data = hass.data.setdefault(DOMAIN, {UDP_LISTENER: None, ENTRIES: {}})
+
+    # Listener is normally already running from async_setup; start as fallback.
+    if not domain_data[UDP_LISTENER]:
+        udp_listener = UDPListener(hass)
+        try:
+            await udp_listener.start()
+        except Exception:
+            raise ConfigEntryError("Failed to start UDP listener.")  # noqa: B904
+        domain_data[UDP_LISTENER] = udp_listener
+    else:
+        udp_listener = domain_data[UDP_LISTENER]
+
+    coordinator = AtombergDataUpdateCoordinator(
+        hass=hass,
+        api=None,
+        udp_listener=udp_listener,
+        config_entry=entry,
+    )
+    domain_data[ENTRIES][entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, LOCAL_UDP_PLATFORMS)
+
+    # Trigger an initial no-op local command to prompt a fresh state broadcast.
+    # If IP is not known yet, this will no-op and state will update on next push.
+    if coordinator.devices:
+        await coordinator.devices[0].async_request_state_refresh()
+
+    return True
+
+
+async def _async_setup_local_discovery_entry(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> bool:
+    """Set up Atomberg local discovery bootstrap entry."""
+    # Discovery is handled globally via async_setup(); this entry only exists
+    # to let the user opt into local autodiscovery from the UI.
     return True
 
 
@@ -90,18 +206,27 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if control_method == ControlMethod.IR:
         return await hass.config_entries.async_unload_platforms(entry, IR_PLATFORMS)
 
+    if control_method == ControlMethod.LOCAL_DISCOVERY:
+        return True
+
+    platforms = (
+        LOCAL_UDP_PLATFORMS
+        if control_method == ControlMethod.LOCAL_UDP
+        else CLOUD_PLATFORMS
+    )
+
     domain_data = hass.data[DOMAIN]
     udp_listener: UDPListener = domain_data[UDP_LISTENER]
 
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, CLOUD_PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms)
     if not unload_ok:
         return False
 
     domain_data[ENTRIES].pop(entry.entry_id, None)
-
     udp_listener.remove_callback(entry)
 
-    if not domain_data[ENTRIES]:
+    # Only close the listener when async_setup did NOT own it and no entries remain.
+    if not domain_data.get(SETUP_ACTIVE, False) and not domain_data[ENTRIES]:
         udp_listener.close()
         domain_data[UDP_LISTENER] = None
 

--- a/custom_components/atomberg/config_flow.py
+++ b/custom_components/atomberg/config_flow.py
@@ -12,7 +12,11 @@ from homeassistant.components.infrared import (
 from homeassistant.components.infrared import (
     async_get_emitters,
 )
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
@@ -28,7 +32,11 @@ from homeassistant.helpers.selector import (
 from .api import AtombergCloudAPI, CannotConnect, InvalidAuth
 from .const import (
     CONF_CONTROL_METHOD,
+    CONF_DEVICE_ID,
+    CONF_DEVICE_SERIES,
+    CONF_DISPLAY_NAME,
     CONF_FAN_MODEL,
+    CONF_IP_ADDRESS,
     CONF_IR_EMITTER_ENTITY,
     CONF_REFRESH_TOKEN,
     CONF_USE_CLOUD_CONTROL,
@@ -77,6 +85,11 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        """Init config flow."""
+        super().__init__()
+        self._discovery_info: dict[str, Any] = {}
+
     @staticmethod
     @callback
     def async_get_options_flow(
@@ -91,7 +104,9 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             control_method = user_input[CONF_CONTROL_METHOD]
             if control_method == ControlMethod.CLOUD:
                 return await self.async_step_cloud()
-            return await self.async_step_ir()
+            if control_method == ControlMethod.IR:
+                return await self.async_step_ir()
+            return await self.async_step_local_discovery()
 
         return self.async_show_form(
             step_id="user",
@@ -100,6 +115,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_CONTROL_METHOD): SelectSelector(
                         SelectSelectorConfig(
                             options=[
+                                ControlMethod.LOCAL_DISCOVERY.value,
                                 ControlMethod.CLOUD.value,
                                 ControlMethod.IR.value,
                             ],
@@ -137,6 +153,19 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="cloud",
             data_schema=CLOUD_DATA_SCHEMA,
             errors=errors,
+        )
+
+    async def async_step_local_discovery(
+        self, user_input: dict[str, Any] | None = None
+    ) -> Any:
+        """Handle local discovery bootstrap setup."""
+        await self.async_set_unique_id("atomberg_local_discovery")
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title="Atomberg Local Discovery",
+            data={
+                CONF_CONTROL_METHOD: ControlMethod.LOCAL_DISCOVERY,
+            },
         )
 
     async def async_step_ir(self, user_input: dict[str, Any] | None = None) -> Any:
@@ -189,6 +218,48 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
+    async def async_step_integration_discovery(
+        self, discovery_info: dict[str, Any]
+    ) -> Any:
+        """Handle a device discovered via UDP broadcast."""
+        device_id = discovery_info[CONF_DEVICE_ID]
+
+        await self.async_set_unique_id(f"atomberg_local_{device_id}")
+        self._abort_if_unique_id_configured()
+
+        self._discovery_info = discovery_info
+        return await self.async_step_local_confirm()
+
+    async def async_step_local_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> Any:
+        """Confirm adding a locally-discovered device."""
+        device_id = self._discovery_info[CONF_DEVICE_ID]
+        device_series = self._discovery_info.get(CONF_DEVICE_SERIES)
+        ip_address = self._discovery_info.get(CONF_IP_ADDRESS, "")
+        display_name = f"Atomberg Fan {device_id[-4:].upper()}"
+
+        if user_input is not None:
+            return self.async_create_entry(
+                title=display_name,
+                data={
+                    CONF_CONTROL_METHOD: ControlMethod.LOCAL_UDP,
+                    CONF_DEVICE_ID: device_id,
+                    CONF_DEVICE_SERIES: device_series,
+                    CONF_DISPLAY_NAME: display_name,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="local_confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "device_id": device_id,
+                "ip_address": ip_address or "unknown",
+                "display_name": display_name,
+            },
+        )
+
 
 class OptionsFlowHandler(OptionsFlow):
     """Handle options flow for Atomberg."""
@@ -197,6 +268,12 @@ class OptionsFlowHandler(OptionsFlow):
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
         """Manage the options."""
+        if not (
+            self.config_entry.data.get(CONF_API_KEY)
+            and self.config_entry.data.get(CONF_REFRESH_TOKEN)
+        ):
+            return self.async_abort(reason="not_supported_for_entry")
+
         if user_input is not None:
             return self.async_create_entry(data=user_input)
 

--- a/custom_components/atomberg/const.py
+++ b/custom_components/atomberg/const.py
@@ -6,20 +6,32 @@ DOMAIN = "atomberg"
 
 UDP_LISTENER = "udp_listener"
 ENTRIES = "entries"
+SETUP_ACTIVE = "setup_active"
 
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_USE_CLOUD_CONTROL = "use_cloud_control"
 CONF_CONTROL_METHOD = "control_method"
 CONF_IR_EMITTER_ENTITY = "ir_emitter_entity"
 CONF_FAN_MODEL = "fan_model"
+CONF_DEVICE_ID = "device_id"
+CONF_DEVICE_SERIES = "device_series"
+CONF_DISPLAY_NAME = "display_name"
+CONF_IP_ADDRESS = "ip_address"
 MANUFACTURER = "Atomberg"
+
+# Sentinel series value used when the device series is unknown.
+UNKNOWN_SERIES = "UNKNOWN"
 
 
 class ControlMethod(StrEnum):
     """Control method for Atomberg devices."""
 
+    # Bootstrap entry used to enable UDP autodiscovery; it does not control a fan.
+    LOCAL_DISCOVERY = "local_discovery"
+
     CLOUD = "cloud"
     IR = "ir"
+    LOCAL_UDP = "local_udp"
 
 
 class FanModel(StrEnum):

--- a/custom_components/atomberg/coordinator.py
+++ b/custom_components/atomberg/coordinator.py
@@ -2,32 +2,91 @@
 
 from logging import getLogger
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .api import AtombergCloudAPI
-from .const import MANUFACTURER
-from .device import AtombergDevice
+from .const import (
+    CONF_DEVICE_ID,
+    CONF_DEVICE_SERIES,
+    CONF_DISPLAY_NAME,
+    MANUFACTURER,
+    UNKNOWN_SERIES,
+)
+from .device import (
+    ATTR_BRIGHTNESS,
+    ATTR_IS_ONLINE,
+    ATTR_LED,
+    ATTR_LIGHT_MODE,
+    ATTR_POWER,
+    ATTR_SLEEP,
+    ATTR_SPEED,
+    ATTR_TIMER_HOURS,
+    ATTR_TIMER_TIME_ELAPSED_MINS,
+    LIGHT_MODE_DAYLIGHT,
+    AtombergDevice,
+)
 from .udp_listener import UDPListener
 
 _LOGGER = getLogger(__name__)
+
+_LOCAL_INITIAL_STATE = {
+    ATTR_POWER: False,
+    ATTR_LED: False,
+    ATTR_SLEEP: False,
+    ATTR_SPEED: 1,
+    ATTR_TIMER_HOURS: 0,
+    ATTR_TIMER_TIME_ELAPSED_MINS: 0,
+    ATTR_IS_ONLINE: False,
+    ATTR_BRIGHTNESS: 1,
+    ATTR_LIGHT_MODE: LIGHT_MODE_DAYLIGHT,
+}
 
 
 class AtombergDataUpdateCoordinator(DataUpdateCoordinator):
     """Atomberg data update coordinator."""
 
     def __init__(
-        self, hass: HomeAssistant, api: AtombergCloudAPI, udp_listener: UDPListener
+        self,
+        hass: HomeAssistant,
+        api: AtombergCloudAPI | None,
+        udp_listener: UDPListener,
+        config_entry: ConfigEntry,
     ) -> None:
         """Init data update coordinator."""
-        super().__init__(hass, _LOGGER, name=f"{MANUFACTURER} Coordinator")
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{MANUFACTURER} Coordinator",
+        )
 
         self.api = api
         self.udp_listener = udp_listener
-        self.devices = [
-            AtombergDevice(data=data, api=self.api, config_entry=self.config_entry)
-            for data in self.api.device_list.values()
-        ]
+
+        if api is not None:
+            # Cloud mode: build device list from API inventory.
+            self.devices = [
+                AtombergDevice(data=data, api=api, config_entry=config_entry)
+                for data in api.device_list.values()
+            ]
+        else:
+            # Local UDP mode: single device from config entry data.
+            cfg = config_entry
+            self.devices = [
+                AtombergDevice(
+                    data={
+                        "device_id": cfg.data[CONF_DEVICE_ID],
+                        "name": cfg.data[CONF_DISPLAY_NAME],
+                        "series": cfg.data.get(CONF_DEVICE_SERIES, UNKNOWN_SERIES),
+                        "model": "Atomberg Fan",
+                        "state": dict(_LOCAL_INITIAL_STATE),
+                    },
+                    api=None,
+                    config_entry=cfg,
+                )
+            ]
 
         # Add callback on udp listener
-        self.udp_listener.add_callback(self.config_entry, self.async_set_updated_data)
+        self.udp_listener.add_callback(config_entry, self.async_set_updated_data)

--- a/custom_components/atomberg/device.py
+++ b/custom_components/atomberg/device.py
@@ -1,4 +1,4 @@
-"""Device as wrapper for Atomberg Cloud APIs."""
+"""Device wrapper for Atomberg fans (cloud and local UDP modes)."""
 
 import json
 import socket
@@ -12,12 +12,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 
 from .api import AtombergCloudAPI
-from .const import CONF_USE_CLOUD_CONTROL
+from .const import CONF_USE_CLOUD_CONTROL, UNKNOWN_SERIES
 
 _LOGGER = getLogger(__name__)
 
-SUPPORTED_BRIGHTNESS_CONTROL_SERIES = ["I1", "M1", "S1", "S2"]
-SUPPORTED_COLOR_EFFECT_SERIES = ["I1"]
+SUPPORTED_BRIGHTNESS_CONTROL_SERIES = ["I1", "M1", "S1", "S2", UNKNOWN_SERIES]
+SUPPORTED_COLOR_EFFECT_SERIES = ["I1", UNKNOWN_SERIES]
 
 ATTR_IS_ONLINE = "is_online"
 ATTR_POWER = "power"
@@ -46,19 +46,19 @@ class AtombergDevice:
     def __init__(
         self,
         data: dict[str, Any],
-        api: AtombergCloudAPI,
+        api: AtombergCloudAPI | None,
         config_entry: ConfigEntry = None,
     ) -> None:
         """Init Atomberg device."""
         self._device_id = data["device_id"]
-        self._color = data["color"]
-        self._series = data["series"]
-        self._model = data["model"]
+        self._color = data.get("color")
+        self._series = data.get("series", UNKNOWN_SERIES)
+        self._model = data.get("model", "Atomberg Fan")
         self._name = data["name"]
         self._api = api
-        self._state: dict = data["state"]
+        self._state: dict = data.get("state", {})
         self._last_seen: int = None
-        self._ip_addr: str = None
+        self._ip_addr: str = data.get("ip_address")
         self._options = config_entry.options if config_entry else {}
 
         # Add options update listener
@@ -70,12 +70,12 @@ class AtombergDevice:
     @property
     def supports_brightness_control(self):
         """Check whether device supports brightness control."""
-        return self.series in SUPPORTED_BRIGHTNESS_CONTROL_SERIES
+        return self._series in SUPPORTED_BRIGHTNESS_CONTROL_SERIES
 
     @property
     def supports_color_effect(self):
         """Check whether device supports color modes."""
-        return self.series in SUPPORTED_COLOR_EFFECT_SERIES
+        return self._series in SUPPORTED_COLOR_EFFECT_SERIES
 
     @property
     def state(self) -> dict[str, Any]:
@@ -139,28 +139,49 @@ class AtombergDevice:
 
     async def _async_send_command(self, command: dict) -> bool:
         """Send command to the device."""
-        if not self._options.get(CONF_USE_CLOUD_CONTROL, False) and self.ip_address:
-            message = json.dumps(command).encode()
-            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-                sent_bytes = sock.sendto(message, (self.ip_address, 5600))
-                res = sent_bytes > 0
-                if res:
-                    _LOGGER.debug(
-                        "Command sent to %s (%s): %s",
-                        self.name,
-                        self.ip_address,
-                        command,
-                    )
-                else:
-                    _LOGGER.error(
-                        "Failed to send command to %s (%s): %s",
-                        self.name,
-                        self.ip_address,
-                        command,
-                    )
-                return res
+        if self._api is None:
+            # Local-only mode — UDP is the only transport.
+            if not self.ip_address:
+                _LOGGER.warning(
+                    "No IP address known for %s yet; command dropped. "
+                    "Waiting for the device to broadcast.",
+                    self.name,
+                )
+                return False
+        elif not self._options.get(CONF_USE_CLOUD_CONTROL, False) and self.ip_address:
+            # Cloud mode with local preference: use UDP when IP is known.
+            pass
         else:
+            # Cloud mode (no local IP or cloud control forced).
             return await self._api.async_send_command(self.id, command)
+
+        # UDP send path (local mode or cloud-with-local-preference).
+        message = json.dumps(command).encode()
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sent_bytes = sock.sendto(message, (self.ip_address, 5600))
+            res = sent_bytes > 0
+            if res:
+                _LOGGER.debug(
+                    "Command sent to %s (%s): %s",
+                    self.name,
+                    self.ip_address,
+                    command,
+                )
+            else:
+                _LOGGER.error(
+                    "Failed to send command to %s (%s): %s",
+                    self.name,
+                    self.ip_address,
+                    command,
+                )
+            return res
+
+    async def async_request_state_refresh(self) -> bool:
+        """Trigger a no-op command that makes the fan broadcast current state.
+
+        Sending {"speedDelta": 0} does not modify state but prompts a fresh state broadcast from the device.
+        """
+        return await self._async_send_command({"speedDelta": 0})
 
     async def async_turn_on(self):
         """Turn on."""
@@ -216,8 +237,8 @@ class AtombergDevice:
         """Set timer."""
         if value not in range(5):
             raise ValueError("Value must in range of 0-4.")
-        if await self._api.async_send_command(self.id, {"timer": value}):
-            _LOGGER.debug("%s: set sleep mode: %d", self.name, value)
+        if await self._async_send_command({"timer": value}):
+            _LOGGER.debug("%s: set timer: %d", self.name, value)
             self.update_state({ATTR_TIMER_HOURS: TIMER_MAPPING[value][0]})
 
     def update_state(self, new_state: dict):

--- a/custom_components/atomberg/entity.py
+++ b/custom_components/atomberg/entity.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
 
-from .const import DOMAIN, ENTRIES, MANUFACTURER
+from .const import CONF_IP_ADDRESS, DOMAIN, ENTRIES, MANUFACTURER
 from .coordinator import AtombergDataUpdateCoordinator
 from .device import (
     ATTR_BRIGHTNESS,
@@ -104,9 +104,11 @@ class AtombergEntity(CoordinatorEntity, Entity):
         if self.coordinator.data["device_id"] != self._device.id:
             return
 
+        was_available = self.available
+        state_string = self.coordinator.data.get("state_string")
         state = {}
         # Decode the state data
-        if state_string := self.coordinator.data.get("state_string"):
+        if state_string:
             value = state_string.split(",")[0].strip()
             if not value.isnumeric():
                 return
@@ -142,7 +144,9 @@ class AtombergEntity(CoordinatorEntity, Entity):
                 state[ATTR_LIGHT_MODE] = light_mode
 
         self._device.update_state({**state, ATTR_IS_ONLINE: True})
-        self._device.update_ip_address(self.coordinator.data.get("ip_address"))
+        self._device.update_ip_address(self.coordinator.data.get(CONF_IP_ADDRESS))
+        if not was_available and not state_string:
+            self.hass.async_create_task(self._device.async_request_state_refresh())
         self._device.update_last_seen(utcnow().timestamp())
         self.update_ha_state_if_required()
 

--- a/custom_components/atomberg/strings.json
+++ b/custom_components/atomberg/strings.json
@@ -2,31 +2,41 @@
   "config": {
     "step": {
       "user": {
-        "title": "Choose Control Method",
-        "description": "Select how you want to control your Atomberg fan. Cloud control requires API credentials. IR control requires an infrared emitter device (e.g., ESPHome IR proxy).",
+        "title": "Choose Setup Type",
+        "description": "Choose how to set up Atomberg. Local Discovery listens for fans on your network and prompts you to add each discovered fan. Cloud uses Atomberg API credentials. IR uses an infrared emitter device (for example, ESPHome IR proxy).",
         "data": {
-          "control_method": "Control method"
+          "control_method": "Setup type"
         }
       },
       "cloud": {
-        "title": "Atomberg Cloud Configuration",
-        "description": "Input the credentials for Atomberg Cloud API.",
+        "title": "Set Up Atomberg Cloud",
+        "description": "Enter your Atomberg Cloud API credentials.",
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "refresh_token": "[%key:common::config_flow::data::refresh_token%]"
         }
       },
       "ir": {
-        "title": "Atomberg IR Configuration",
-        "description": "Select your fan model and the infrared transmitter entity to use for controlling your Atomberg fan.",
+        "title": "Set Up IR Control",
+        "description": "Select your fan model and the infrared transmitter entity used to control your Atomberg fan.",
         "data": {
           "fan_model": "Fan model",
           "ir_emitter_entity": "Infrared transmitter"
         },
         "data_description": {
           "fan_model": "The model of your Atomberg fan.",
-          "ir_emitter_entity": "The infrared transmitter entity to use for sending commands."
+          "ir_emitter_entity": "The infrared transmitter entity used to send commands."
         }
+      },
+      "local_discovery": {
+        "title": "Enable Local Discovery",
+        "description": "Start local UDP discovery for Atomberg fans on your network. When a fan is discovered, you will be prompted to confirm adding it.",
+        "data": {}
+      },
+      "local_confirm": {
+        "title": "Add Discovered Atomberg Fan",
+        "description": "Discovered an Atomberg fan with device ID `{device_id}` at IP address {ip_address}. It will be added as `{display_name}`.",
+        "data": {}
       }
     },
     "error": {
@@ -35,10 +45,13 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "no_ir_emitters": "No infrared transmitter entities found. Please set up an infrared device first (e.g., ESPHome IR proxy)."
+      "no_ir_emitters": "No infrared transmitter entities found. Set up an infrared device first (for example, ESPHome IR proxy)."
     }
   },
   "options": {
+    "abort": {
+      "not_supported_for_entry": "No configurable options are available for this entry."
+    },
     "step": {
       "init": {
         "title": "[%key:common::options_flow::title%]",
@@ -88,8 +101,10 @@
   "selector": {
     "control_method": {
       "options": {
+        "local_discovery": "Local Discovery (UDP)",
         "cloud": "Cloud API",
-        "ir": "Infrared (IR)"
+        "ir": "Infrared (IR)",
+        "local_udp": "Local UDP Device"
       }
     },
     "fan_model": {

--- a/custom_components/atomberg/translations/en.json
+++ b/custom_components/atomberg/translations/en.json
@@ -2,31 +2,41 @@
   "config": {
     "step": {
       "user": {
-        "title": "Choose Control Method",
-        "description": "Select how you want to control your Atomberg fan. Cloud control requires API credentials. IR control requires an infrared emitter device (e.g., ESPHome IR proxy).",
+        "title": "Choose Setup Type",
+        "description": "Choose how to set up Atomberg. Local Discovery listens for fans on your network and prompts you to add each discovered fan. Cloud uses Atomberg API credentials. IR uses an infrared emitter device (for example, ESPHome IR proxy).",
         "data": {
-          "control_method": "Control method"
+          "control_method": "Setup type"
         }
       },
       "cloud": {
-        "title": "Atomberg Cloud Configuration",
-        "description": "Input the credentials for Atomberg Cloud API.",
+        "title": "Set Up Atomberg Cloud",
+        "description": "Enter your Atomberg Cloud API credentials.",
         "data": {
           "api_key": "API key",
           "refresh_token": "Refresh token"
         }
       },
       "ir": {
-        "title": "Atomberg IR Configuration",
-        "description": "Select your fan model and the infrared transmitter entity to use for controlling your Atomberg fan.",
+        "title": "Set Up IR Control",
+        "description": "Select your fan model and the infrared transmitter entity used to control your Atomberg fan.",
         "data": {
           "fan_model": "Fan model",
           "ir_emitter_entity": "Infrared transmitter"
         },
         "data_description": {
           "fan_model": "The model of your Atomberg fan.",
-          "ir_emitter_entity": "The infrared transmitter entity to use for sending commands."
+          "ir_emitter_entity": "The infrared transmitter entity used to send commands."
         }
+      },
+      "local_discovery": {
+        "title": "Enable Local Discovery",
+        "description": "Start local UDP discovery for Atomberg fans on your network. When a fan is discovered, you will be prompted to confirm adding it.",
+        "data": {}
+      },
+      "local_confirm": {
+        "title": "Add Discovered Atomberg Fan",
+        "description": "Discovered an Atomberg fan with device ID `{device_id}` at IP address {ip_address}. It will be added as `{display_name}`.",
+        "data": {}
       }
     },
     "error": {
@@ -35,10 +45,13 @@
       "unknown": "An unknown error occurred. See log for details."
     },
     "abort": {
-      "no_ir_emitters": "No infrared transmitter entities found. Please set up an infrared device first (e.g., ESPHome IR proxy)."
+      "no_ir_emitters": "No infrared transmitter entities found. Set up an infrared device first (for example, ESPHome IR proxy)."
     }
   },
   "options": {
+    "abort": {
+      "not_supported_for_entry": "No configurable options are available for this entry."
+    },
     "step": {
       "init": {
         "title": "Options",
@@ -88,8 +101,10 @@
   "selector": {
     "control_method": {
       "options": {
+        "local_discovery": "Local Discovery (UDP)",
         "cloud": "Cloud API",
-        "ir": "Infrared (IR)"
+        "ir": "Infrared (IR)",
+        "local_udp": "Local UDP Device"
       }
     },
     "fan_model": {

--- a/custom_components/atomberg/udp_listener.py
+++ b/custom_components/atomberg/udp_listener.py
@@ -7,6 +7,8 @@ from logging import getLogger
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+DISCOVERY_CALLBACK_KEY = "_discovery"
+
 _LOGGER = getLogger(__name__)
 
 
@@ -33,6 +35,23 @@ class UDPListener(asyncio.DatagramProtocol):
 
         return message, addr[0]
 
+    @staticmethod
+    def _extract_device_details(device_id_field: str) -> dict[str, str]:
+        """Extract device_id and optional series from raw device identifier.
+
+        Some UDP payloads publish identifiers in the form `<device_id>_<series>`
+        such as `<device_id>_R1`.
+        """
+        device_id_raw = device_id_field.strip()
+        if not device_id_raw:
+            return {}
+
+        parts = device_id_raw.split("_", 1)
+        details = {"device_id": parts[0]}
+        if len(parts) > 1 and parts[1].strip():
+            details["device_series"] = parts[1].strip().upper()
+        return details
+
     def datagram_received(self, data, addr):
         """Decode data when broadcast received."""
         message, ip_addr = self.parse_datagram(data, addr)
@@ -44,18 +63,24 @@ class UDPListener(asyncio.DatagramProtocol):
             msg_data_bytes = bytes.fromhex(message)
             msg_data.update(json.loads(msg_data_bytes))
         except ValueError:
-            msg_data.update({"device_id": message.split("_")[0]})
+            msg_data.update(self._extract_device_details(message))
+
+        # Normalize device metadata from any payload form.
+        if device_id_field := msg_data.get("device_id"):
+            msg_data.update(self._extract_device_details(device_id_field))
 
         for func in self._callbacks.values():
             func(msg_data)
 
-    def add_callback(self, entry: ConfigEntry, callback):
-        """Add a callback."""
-        self._callbacks[entry.entry_id] = callback
+    def add_callback(self, key: str | ConfigEntry, callback):
+        """Add a callback keyed by entry_id or an arbitrary string."""
+        key_str = key if isinstance(key, str) else key.entry_id
+        self._callbacks[key_str] = callback
 
-    def remove_callback(self, entry: ConfigEntry):
-        """Remove a callback."""
-        self._callbacks.pop(entry.entry_id, None)
+    def remove_callback(self, key: str | ConfigEntry):
+        """Remove a callback keyed by entry_id or an arbitrary string."""
+        key_str = key if isinstance(key, str) else key.entry_id
+        self._callbacks.pop(key_str, None)
 
     async def start(self):
         """Start listening."""


### PR DESCRIPTION
- Add integration discovery flow which discovers devices via UDP and allows onboarding
- Add local UDP device mode and coordinator/device support without being tied to the cloud api configuration
- Update options behavior, UDP parsing, and user-facing strings/translations for consistency

Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Local device discovery via UDP network broadcasts
  * New local UDP control method for direct device management without cloud connectivity
  * Enhanced setup flow with local discovery configuration options
  * Devices now support both cloud and local control methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->