### PR TITLE
Add 'R3' to supported series in API

### DIFF
--- a/custom_components/atomberg/api.py
+++ b/custom_components/atomberg/api.py
@@ -15,7 +15,7 @@ from requests import Response
 
 _LOGGER = getLogger(__name__)
 
-SUPPORTED_SERIES = ["R1", "R2", "K1", "I1", "I2", "I3", "I5", "M1", "M2", "S1", "S2"]
+SUPPORTED_SERIES = ["R1", "R2", "R3", "K1", "I1", "I2", "I3", "I5", "M1", "M2", "S1", "S2"]
 
 
 class AtombergCloudAPI:


### PR DESCRIPTION
R3 model of Renessa Halo model works as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded device compatibility to include Atomberg R3 series devices. These devices are now supported for discovery and synchronization alongside existing supported series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->