### PR TITLE
Replace fabricated Atomberg IR hex codes with captured raw codes

### DIFF
--- a/custom_components/atomberg/atomberg_ir_codes.py
+++ b/custom_components/atomberg/atomberg_ir_codes.py
@@ -1,29 +1,85 @@
-"""Atomberg IR NEC command definitions."""
+"""Atomberg IR command definitions.
+
+IR codes are raw captures from an original Atomberg remote, stored as
+Broadlink IR packets (base64) and decoded into microsecond timings at import
+time. Replaying the captured timings reproduces the exact waveform the remote
+sends, including its calibration pulses and NEC repeat frame.
+"""
+
+import base64
 
 from infrared_protocols.commands import Command as InfraredCommand
 from infrared_protocols.commands.nec import NECCommand
 
-ATOMBERG_IR_ADDRESS = 0xF300
 ATOMBERG_IR_MODULATION = 38000
+
+# Raw captures from an original Atomberg remote (Broadlink IR packet format).
+ATOMBERG_IR_CODES = {
+    "led": "JgBsAAQACE8EAAKIBgAKQQQAAoYEAAUdBAAChwUAB8EFAAvcBgADBwABHpARExESExETERMREhETEhISETYTNRIRExETNhE2EjUTNRI1EzUSNRISEjYSERMREzUSEhISEhISNRMREzUSNRISEgANBQ==",
+    "toggle": "JgBQAAABH44TERMREhISERMSEhISEhESEzUSNRMRExIRNhI1EzUSNRM1EhISEhETEjUTERIREzYRExE2EzQTNRISEjYRNhMREgAFQAABHkcTAA0F",
+    "one": "JgBUAAUACa8AAR6PEhITERIRExETEhISEhIREhI1EzUTERMREjYSNRI2EjUTNRI2ERISNhISEhETERM1EhISEhI1ExETNBM2ETYSEhMABT0AASFHEgANBQ==",
+    "two": "JgBsAAQAAocEAAUeCAACkx0ACh4HAAKQCgAFDAkABPsAAR+PEhITERIRExETEhISERMREhI2EjUTERITETYSNRM0EzUSExESEhISEhI1ExETERM1EjUSNhI1EzQTEhI2ETYTERIABUEAAR5IEQANBQ==",
+    "three": "JgCGAAUABRYEAAfeFAAExxIABQQVAAoZBAAC4RoOBwAMgAQACgUEAAKHBAAFHgUAAocTAAo3BQAEBwABH44TEhISERMREhMRExETERIREzYRNhISEhISNRM0EzYRNhISEjUTERM1EhISEhETETYTNBMREzUSEhI1EzUSNRMREwAFQAABH0cSAA0F",
+    "four": "JgBkAAUABz4HAAoWBwACtQABH44SEhMREhISERMSEhISEhETETYTNBMRExESNhI1EzUSNRM1EjYREhISEjYSERMREzUSEhISEjUTNRIREzYRNhISEgAFQAABH0cTAAv1AAEfRxMADQU=",
+    "five": "JgBQAAABH48SEhISEhIRExIRExETERMREjYSNRMRExETNBM2ETYSNRMRExESEhI2EhIREhISEjYSNRM1EjYREhI2EjUTNRISEgAFQAABH0cTAA0F",
+    "boost": "JgBYAAYABRMEAArMAAEfjhMRExETEhISERISEhISExESNRM1EhISEhI1EzUSNRM1EjYRNhM0EzUSEhISEhISNRMRExESEhISEjYRNhM0ExETAAVAAAEeSBIADQU=",
+    "timer": "JgBQAAABHZASEhISEhETERMRExIREhISEjYSNRMREhISNhI1EjYSNRMREjYSNRISEzQTERMSEjUSNhESExETNRIREzYRNhISEwAFPwABH0cSAA0F",
+    "sleep": "JgBQAAABH44TERMRExETERISEhISEhISETYTNBMRExETNRI2ETYSNRMREzQTNhE2EhITERISEjUTNRISEhIRExE2EzQTNRISEgAFQAABHkcTAA0F",
+}
+
+
+class RawTimingCommand(InfraredCommand):
+    """IR command that replays captured raw timings."""
+
+    def __init__(self, timings: list[int], *, modulation: int) -> None:
+        """Initialize with raw microsecond timings."""
+        super().__init__(modulation=modulation, repeat_count=0)
+        self._timings = tuple(timings)
+
+    def get_raw_timings(self) -> list[int]:
+        """Return the raw timings (positive=pulse, negative=space)."""
+        return list(self._timings)
+
+
+def _decode_broadlink_packet(packet: bytes, *, tick: float = 32.84) -> list[int]:
+    """Decode a Broadlink IR packet into signed microsecond timings."""
+    durations: list[int] = []
+    index = 4
+    end = min(256 * packet[3] + packet[2] + 4, len(packet))
+    while index < end:
+        chunk = packet[index]
+        index += 1
+        if chunk == 0:
+            chunk = 256 * packet[index] + packet[index + 1]
+            index += 2
+        durations.append(int(chunk * tick))
+    return [
+        duration if index % 2 == 0 else -duration
+        for index, duration in enumerate(durations)
+    ]
+
+
+def _make_command(code: str) -> RawTimingCommand:
+    """Build a raw timing command from a base64 Broadlink IR packet."""
+    return RawTimingCommand(
+        _decode_broadlink_packet(base64.b64decode(code)),
+        modulation=ATOMBERG_IR_MODULATION,
+    )
 
 
 class AtombergIRCommand:
-    """NEC command codes for Atomberg fans."""
+    """Captured IR commands for Atomberg fans."""
 
-    POWER = 0x6E91
-    SPEED_1 = 0x748B
-    SPEED_2 = 0x6F90
-    SPEED_3 = 0x758A
-    SPEED_4 = 0x6C93
-    SPEED_5 = 0x7788
-    BOOST = 0x708F
-    SLEEP = 0x718E
-    LED = 0xE916
-    TIMER = 0x6996
-    TIMER_1H = 0xA15E
-    TIMER_2H = 0x619E
-    TIMER_3H = 0x49B6
-    TIMER_6H = 0x31CE
+    POWER = _make_command(ATOMBERG_IR_CODES["toggle"])
+    SPEED_1 = _make_command(ATOMBERG_IR_CODES["one"])
+    SPEED_2 = _make_command(ATOMBERG_IR_CODES["two"])
+    SPEED_3 = _make_command(ATOMBERG_IR_CODES["three"])
+    SPEED_4 = _make_command(ATOMBERG_IR_CODES["four"])
+    SPEED_5 = _make_command(ATOMBERG_IR_CODES["five"])
+    BOOST = _make_command(ATOMBERG_IR_CODES["boost"])
+    SLEEP = _make_command(ATOMBERG_IR_CODES["sleep"])
+    LED = _make_command(ATOMBERG_IR_CODES["led"])
+    TIMER = _make_command(ATOMBERG_IR_CODES["timer"])
 
 
 SPEED_MAP = {
@@ -34,15 +90,6 @@ SPEED_MAP = {
     5: AtombergIRCommand.SPEED_5,
     6: AtombergIRCommand.BOOST,
 }
-
-
-def make_atomberg_command(command: int) -> InfraredCommand:
-    """Create an InfraredCommand from an Atomberg NEC command code."""
-    return NECCommand(
-        address=ATOMBERG_IR_ADDRESS,
-        command=command,
-        modulation=ATOMBERG_IR_MODULATION,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -58,16 +105,23 @@ EFFICIO_PLUS_PEDESTAL_IR_ADDRESS = 0x0040
 class EfficioPlusPedestalIRCommand:
     """NEC command codes for Atomberg Efficio+ 400mm Pedestal Swing Fan."""
 
-    POWER = 0x4A
-    TOGGLE_SPEED = 0xC4
-    SWING = 0x38
-    TIMER = 0x15
-
-
-def make_efficio_plus_pedestal_command(command: int) -> InfraredCommand:
-    """Create an InfraredCommand for the Efficio+ 400mm Pedestal Swing Fan."""
-    return NECCommand(
+    POWER = NECCommand(
         address=EFFICIO_PLUS_PEDESTAL_IR_ADDRESS,
-        command=command,
+        command=0x4A,
+        modulation=ATOMBERG_IR_MODULATION,
+    )
+    TOGGLE_SPEED = NECCommand(
+        address=EFFICIO_PLUS_PEDESTAL_IR_ADDRESS,
+        command=0xC4,
+        modulation=ATOMBERG_IR_MODULATION,
+    )
+    SWING = NECCommand(
+        address=EFFICIO_PLUS_PEDESTAL_IR_ADDRESS,
+        command=0x38,
+        modulation=ATOMBERG_IR_MODULATION,
+    )
+    TIMER = NECCommand(
+        address=EFFICIO_PLUS_PEDESTAL_IR_ADDRESS,
+        command=0x15,
         modulation=ATOMBERG_IR_MODULATION,
     )

--- a/custom_components/atomberg/ir_button.py
+++ b/custom_components/atomberg/ir_button.py
@@ -28,21 +28,25 @@ BUTTON_DESCRIPTIONS: tuple[AtombergIrButtonDescription, ...] = (
     AtombergIrButtonDescription(
         key="boost",
         translation_key="boost",
+        icon="mdi:fan-speed-plus",
         command=AtombergIRCommand.BOOST,
     ),
     AtombergIrButtonDescription(
         key="led",
         translation_key="led",
+        icon="mdi:lightbulb-on-outline",
         command=AtombergIRCommand.LED,
     ),
     AtombergIrButtonDescription(
         key="sleep",
         translation_key="sleep",
+        icon="mdi:sleep",
         command=AtombergIRCommand.SLEEP,
     ),
     AtombergIrButtonDescription(
         key="timer",
         translation_key="timer",
+        icon="mdi:timer",
         command=AtombergIRCommand.TIMER,
     ),
 )

--- a/custom_components/atomberg/ir_button.py
+++ b/custom_components/atomberg/ir_button.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from infrared_protocols.commands import Command as InfraredCommand
-
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from infrared_protocols.commands import Command as InfraredCommand
 
 from .atomberg_ir_codes import AtombergIRCommand, EfficioPlusPedestalIRCommand
 from .const import CONF_FAN_MODEL, FanModel

--- a/custom_components/atomberg/ir_button.py
+++ b/custom_components/atomberg/ir_button.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from infrared_protocols.commands import Command as InfraredCommand
+
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -20,49 +22,29 @@ PARALLEL_UPDATES = 1
 class AtombergIrButtonDescription(ButtonEntityDescription):
     """Describes an Atomberg IR button entity."""
 
-    command_code: int
+    command: InfraredCommand
 
 
 BUTTON_DESCRIPTIONS: tuple[AtombergIrButtonDescription, ...] = (
     AtombergIrButtonDescription(
         key="boost",
         translation_key="boost",
-        command_code=AtombergIRCommand.BOOST,
+        command=AtombergIRCommand.BOOST,
     ),
     AtombergIrButtonDescription(
         key="led",
         translation_key="led",
-        command_code=AtombergIRCommand.LED,
+        command=AtombergIRCommand.LED,
     ),
     AtombergIrButtonDescription(
         key="sleep",
         translation_key="sleep",
-        command_code=AtombergIRCommand.SLEEP,
+        command=AtombergIRCommand.SLEEP,
     ),
     AtombergIrButtonDescription(
         key="timer",
         translation_key="timer",
-        command_code=AtombergIRCommand.TIMER,
-    ),
-    AtombergIrButtonDescription(
-        key="timer_1h",
-        translation_key="timer_1h",
-        command_code=AtombergIRCommand.TIMER_1H,
-    ),
-    AtombergIrButtonDescription(
-        key="timer_2h",
-        translation_key="timer_2h",
-        command_code=AtombergIRCommand.TIMER_2H,
-    ),
-    AtombergIrButtonDescription(
-        key="timer_3h",
-        translation_key="timer_3h",
-        command_code=AtombergIRCommand.TIMER_3H,
-    ),
-    AtombergIrButtonDescription(
-        key="timer_6h",
-        translation_key="timer_6h",
-        command_code=AtombergIRCommand.TIMER_6H,
+        command=AtombergIRCommand.TIMER,
     ),
 )
 
@@ -72,17 +54,17 @@ EFFICIO_PLUS_PEDESTAL_BUTTON_DESCRIPTIONS: tuple[AtombergIrButtonDescription, ..
     AtombergIrButtonDescription(
         key="toggle_speed",
         translation_key="toggle_speed",
-        command_code=EfficioPlusPedestalIRCommand.TOGGLE_SPEED,
+        command=EfficioPlusPedestalIRCommand.TOGGLE_SPEED,
     ),
     AtombergIrButtonDescription(
         key="swing",
         translation_key="swing",
-        command_code=EfficioPlusPedestalIRCommand.SWING,
+        command=EfficioPlusPedestalIRCommand.SWING,
     ),
     AtombergIrButtonDescription(
         key="timer",
         translation_key="timer",
-        command_code=EfficioPlusPedestalIRCommand.TIMER,
+        command=EfficioPlusPedestalIRCommand.TIMER,
     ),
 )
 
@@ -120,4 +102,4 @@ class AtombergIrButton(AtombergIrEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self._send_command(self.entity_description.command_code)
+        await self._send_command(self.entity_description.command)

--- a/custom_components/atomberg/ir_button.py
+++ b/custom_components/atomberg/ir_button.py
@@ -28,7 +28,7 @@ BUTTON_DESCRIPTIONS: tuple[AtombergIrButtonDescription, ...] = (
     AtombergIrButtonDescription(
         key="boost",
         translation_key="boost",
-        icon="mdi:fan-speed-plus",
+        icon="mdi:fan-alert",
         command=AtombergIRCommand.BOOST,
     ),
     AtombergIrButtonDescription(

--- a/custom_components/atomberg/ir_entity.py
+++ b/custom_components/atomberg/ir_entity.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import logging
 
-from infrared_protocols.commands import Command as InfraredCommand
-
 from homeassistant.components.infrared import async_send_command
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE
@@ -13,6 +11,7 @@ from homeassistant.core import Event, EventStateChangedData, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change_event
+from infrared_protocols.commands import Command as InfraredCommand
 
 from .const import (
     CONF_FAN_MODEL,

--- a/custom_components/atomberg/ir_entity.py
+++ b/custom_components/atomberg/ir_entity.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+from infrared_protocols.commands import Command as InfraredCommand
+
 from homeassistant.components.infrared import async_send_command
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE
@@ -12,7 +14,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change_event
 
-from .atomberg_ir_codes import make_atomberg_command, make_efficio_plus_pedestal_command
 from .const import (
     CONF_FAN_MODEL,
     CONF_IR_EMITTER_ENTITY,
@@ -78,15 +79,11 @@ class AtombergIrEntity(Entity):
             ir_state is not None and ir_state.state != STATE_UNAVAILABLE
         )
 
-    async def _send_command(self, command_code: int) -> None:
+    async def _send_command(self, command: InfraredCommand) -> None:
         """Send an IR command to the Atomberg fan."""
-        if self._fan_model == FanModel.EFFICIO_PLUS_400MM_PEDESTAL:
-            ir_command = make_efficio_plus_pedestal_command(command_code)
-        else:
-            ir_command = make_atomberg_command(command_code)
         await async_send_command(
             self.hass,
             self._infrared_entity_id,
-            ir_command,
+            command,
             context=self._context,
         )

--- a/custom_components/atomberg/translations/en.json
+++ b/custom_components/atomberg/translations/en.json
@@ -65,18 +65,6 @@
       "timer": {
         "name": "Timer"
       },
-      "timer_1h": {
-        "name": "Timer 1 Hour"
-      },
-      "timer_2h": {
-        "name": "Timer 2 Hours"
-      },
-      "timer_3h": {
-        "name": "Timer 3 Hours"
-      },
-      "timer_6h": {
-        "name": "Timer 6 Hours"
-      },
       "toggle_speed": {
         "name": "Toggle Speed"
       },


### PR DESCRIPTION
- Implemented updated IR codes captured using Atomberg Universal Remote control
- Tested locally with Atomberge Renesa fan, works flawlessly
fixes https://github.com/dasshubham762/atomberg-integration/issues/73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated fan infrared control to use captured signals for more reliable command transmission.
  * Simplified command handling across supported Atomberg fan models.
  * Preserved standard controls such as power, speed, swing, boost, LED, sleep, and timer functions.

* **Removed**
  * Removed separate 1-hour, 2-hour, 3-hour, and 6-hour timer button options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->